### PR TITLE
Casos de ```DET NOUN```, onde ```DET``` tem relação det com outro token

### DIFF
--- a/documents/CF0015.conllu
+++ b/documents/CF0015.conllu
@@ -141,7 +141,7 @@
 22	autoritários	autoritário	ADJ	ADJ|M|P|@N<	Gender=Masc|Number=Plur	21	amod	_	SpaceAfter=No
 23	,	,	PUNCT	PU|@PU	_	24	punct	_	_
 24	coordenando	coordenar	VERB	<mv>|V|GER|@ICL-<ADVL	VerbForm=Ger	18	advcl	_	_
-25	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
+25	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
 26	entidade	entidade	NOUN	<np-def>|N|F|S|@<ACC	Gender=Fem|Number=Sing	24	obj	_	_
 27	de	de	ADP	PRP|@<ACC	_	28	case	_	_
 28	maneira	maneira	NOUN	<np-idf>|N|F|S|@P<	Gender=Fem|Number=Sing	24	obl	_	_

--- a/documents/CF0028.conllu
+++ b/documents/CF0028.conllu
@@ -12,7 +12,7 @@
 7	começou	começar	VERB	<aux>|V|PS|3S|IND|@FS-N<	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	acl:relcl	_	MWE=começou_a|MWEPOS=AUX
 8	a	a	SCONJ	PRP|@PRT-AUX<	_	9	mark	_	_
 9	coordenar	coordenar	VERB	<mv>|V|INF|@ICL-AUX<	VerbForm=Inf	7	xcomp	_	_
-10	as	o	DET	<artd>|ART|F|P|@>N	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	14	det	_	_
+10	as	o	DET	<artd>|ART|F|P|@>N	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	11	det	_	_
 11	ações	ação	NOUN	<np-def>|N|F|P|@<ACC	Gender=Fem|Number=Plur	9	obj	_	_
 12-13	no	_	_	_	_	_	_	_	_
 12	em	em	ADP	<sam->|PRP|@<ACC	_	14	case	_	_

--- a/documents/CF0045.conllu
+++ b/documents/CF0045.conllu
@@ -68,7 +68,7 @@
 13	ainda	ainda	ADV	ADV|@ADVL>	_	14	advmod	_	_
 14	terá	ter	VERB	<mv>|V|FUT|3S|IND|@FS-<ACC	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	5	ccomp	_	_
 15	várias	várias	DET	<quant>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Ind	19	det	_	_
-16	outras	outro	DET	<diff>|<KOMP>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Ind	19	det	_	_
+16	outras	outro	DET	<diff>|<KOMP>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Ind	17	det	_	_
 17	oportunidades	oportunidade	NOUN	<np-idf>|N|F|P|@<ACC	Gender=Fem|Number=Plur	14	obj	_	_
 18	para	para	SCONJ	PRP|@<ACC	_	19	mark	_	_
 19	disputar	disputar	VERB	<mv>|V|INF|@ICL-P<	VerbForm=Inf	17	acl	_	_

--- a/documents/CF0045.conllu
+++ b/documents/CF0045.conllu
@@ -67,7 +67,7 @@
 12	,	,	PUNCT	PU|@PU	_	11	punct	_	_
 13	ainda	ainda	ADV	ADV|@ADVL>	_	14	advmod	_	_
 14	terá	ter	VERB	<mv>|V|FUT|3S|IND|@FS-<ACC	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	5	ccomp	_	_
-15	várias	várias	DET	<quant>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Ind	19	det	_	_
+15	várias	várias	DET	<quant>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Ind	17	det	_	_
 16	outras	outro	DET	<diff>|<KOMP>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Ind	17	det	_	_
 17	oportunidades	oportunidade	NOUN	<np-idf>|N|F|P|@<ACC	Gender=Fem|Number=Plur	14	obj	_	_
 18	para	para	SCONJ	PRP|@<ACC	_	19	mark	_	_

--- a/documents/CF0058.conllu
+++ b/documents/CF0058.conllu
@@ -47,7 +47,7 @@
 27	Johnson	Johnson	PROPN	_	Number=Sing	26	flat:name	_	_
 28	teria	ter	AUX	<aux>|V|COND|3S|@FS-N<	Mood=Cnd|Number=Sing|Person=3|VerbForm=Fin	29	aux	_	_
 29	feito	fazer	VERB	<mv>|V|PCP|@ICL-AUX<	VerbForm=Part	24	acl:relcl	_	_
-30	um	um	DET	<arti>|ART|M|S|@>N	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	34	det	_	_
+30	um	um	DET	<arti>|ART|M|S|@>N	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
 31	pacto	pacto	NOUN	<np-idf>|N|M|S|@<ACC	Gender=Masc|Number=Sing	29	obj	_	_
 32	com	com	ADP	PRP|@<ACC	_	34	case	_	_
 33	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	34	det	_	_

--- a/documents/CF0072.conllu
+++ b/documents/CF0072.conllu
@@ -6,7 +6,7 @@
 2	--	--	PUNCT	PU|@PU	_	1	punct	_	_
 3	Já	já	ADV	ADV|@ADVL>	_	4	advmod	_	_
 4	pedimos	pedir	VERB	<mv>|V|PS|1P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	1	parataxis	_	_
-5	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+5	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
 6	criação	criação	NOUN	<np-def>|N|F|S|@<ACC	Gender=Fem|Number=Sing	4	obj	_	_
 7	de	de	ADP	PRP|@N<	_	9	case	_	_
 8	um	um	DET	<arti>|ART|M|S|@>N	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_

--- a/documents/CF0077.conllu
+++ b/documents/CF0077.conllu
@@ -64,7 +64,7 @@
 14	próprio	próprio	DET	<ident>|DET|M|S|@>N	Gender=Masc|Number=Sing|PronType=Emp	15	det	_	_
 15	setor	setor	NOUN	<np-def>|N|M|S|@SUBJ>	Gender=Masc|Number=Sing	16	nsubj	_	_
 16	negocie	negociar	VERB	<mv>|V|PR|3S|SUBJ|@FS-<ACC	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	ccomp	_	_
-17	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
+17	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
 18	conversão	conversão	NOUN	<np-def>|N|F|S|@<ACC	Gender=Fem|Number=Sing	16	obj	_	_
 19-20	dos	_	_	_	_	_	_	_	_
 19	de	de	ADP	<sam->|PRP|@N<	_	21	case	_	_

--- a/documents/CF0090.conllu
+++ b/documents/CF0090.conllu
@@ -24,7 +24,7 @@
 9	(	(	PUNCT	PU|@PU	_	10	punct	_	SpaceAfter=No
 10	Equador	Equador	PROPN	PROP|M|S|@N<PRED	Gender=Masc|Number=Sing	8	parataxis	_	SpaceAfter=No
 11	)	)	PUNCT	PU|@PU	_	10	punct	_	_
-12	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+12	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	contaminação	contaminação	NOUN	<np-def>|N|F|S|@<ACC	Gender=Fem|Number=Sing	5	obj	_	_
 14	causada	causar	VERB	<mv>|V|PCP|F|S|@ICL-N<	Gender=Fem|Number=Sing|VerbForm=Part|Voice=Pass	20	acl	_	_
 15	por	por	ADP	PRP|@PASS	_	16	case	_	_

--- a/documents/CF0091.conllu
+++ b/documents/CF0091.conllu
@@ -20,7 +20,7 @@
 1	Para	para	SCONJ	PRP|@ADVL>	_	2	mark	_	_
 2	tentar	tentar	VERB	<mv>|V|INF|@ICL-P<	VerbForm=Inf	32	advcl	_	_
 3	resolver	resolver	VERB	<mv>|V|INF|@ICL-<ACC	VerbForm=Inf	2	xcomp	_	_
-4	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+4	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
 5	problema	problema	NOUN	<np-def>|N|M|S|@<ACC	Gender=Masc|Number=Sing	3	obj	_	_
 6-7	do	_	_	_	_	_	_	_	_
 6	de	de	ADP	<sam->|PRP|@N<	_	8	case	_	_

--- a/documents/CF0161.conllu
+++ b/documents/CF0161.conllu
@@ -68,7 +68,7 @@
 # sent_id = CF161-2
 # source = CETENFolha n=161 cad=Ilustrada sec=nd sem=94b
 # id = 672
-1	O	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
+1	O	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
 2	jovem	jovem	NOUN	<n>|<first-cjt>|ADJ|M|S|@>N	Gender=Masc|Number=Sing	11	amod	_	_
 3	(	(	PUNCT	PU|@PU	_	5	punct	_	SpaceAfter=No
 4	34	34	NUM	<card>|NUM|M|P|@>N	NumType=Card	5	nummod	_	_

--- a/documents/CF0167.conllu
+++ b/documents/CF0167.conllu
@@ -124,7 +124,7 @@
 17	fiscal	fiscal	ADJ	ADJ|M|S|@N<	Gender=Masc|Number=Sing	16	amod	_	SpaceAfter=No
 18	,	,	PUNCT	PU|@PU	_	3	punct	_	_
 19	qual	qual	PRON	<first-cjt>|<rel>|DET|F|S|@<ACC	Gender=Masc|Number=Sing|PronType=Rel	3	obj	_	_
-20	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
+20	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
 21	incidência	incidência	NOUN	<np-def>|N|F|S|@<SUBJ	Gender=Fem|Number=Sing	19	nsubj	_	_
 22	efetiva	efetivo	ADJ	ADJ|F|S|@N<	Gender=Fem|Number=Sing	29	amod	_	_
 23	de	de	ADP	PRP|@N<	_	24	case	_	_

--- a/documents/CF0188.conllu
+++ b/documents/CF0188.conllu
@@ -5,7 +5,7 @@
 1	O	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
 2	PDT	PDT	PROPN	PROP|M|S|@SUBJ>	Gender=Masc|Number=Sing	3	nsubj	_	_
 3	propõe	propor	VERB	<mv>|V|PR|3S|IND|@FS-STA	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	uma	um	DET	<arti>|ART|F|S|@>N	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+4	uma	um	DET	<arti>|ART|F|S|@>N	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
 5	auditoria	auditoria	NOUN	<np-idf>|N|F|S|@<ACC	Gender=Fem|Number=Sing	3	obj	_	_
 6	para	para	ADP	PRP|@<ACC	_	8	case	_	_
 7	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_

--- a/documents/CF0216.conllu
+++ b/documents/CF0216.conllu
@@ -29,7 +29,7 @@
 9	Sul	Sul	PROPN	PROP|@P<	Number=Sing	5	nmod	_	_
 10	vai	ir	AUX	<aux>|V|PR|3S|IND|@FS-STA	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
 11	combater	combater	VERB	<mv>|V|INF|@ICL-AUX<	VerbForm=Inf	0	root	_	_
-12	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+12	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	pesca	pesca	NOUN	<np-def>|N|F|S|@<ACC	Gender=Fem|Number=Sing	11	obj	_	_
 14	predatória	predatório	ADJ	ADJ|F|S|@N<	Gender=Fem|Number=Sing	17	amod	_	_
 15	durante	durante	ADP	PRP|@<ACC	_	17	case	_	_

--- a/documents/CF0216.conllu
+++ b/documents/CF0216.conllu
@@ -31,7 +31,7 @@
 11	combater	combater	VERB	<mv>|V|INF|@ICL-AUX<	VerbForm=Inf	0	root	_	_
 12	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
 13	pesca	pesca	NOUN	<np-def>|N|F|S|@<ACC	Gender=Fem|Number=Sing	11	obj	_	_
-14	predatória	predatório	ADJ	ADJ|F|S|@N<	Gender=Fem|Number=Sing	17	amod	_	_
+14	predatória	predatório	ADJ	ADJ|F|S|@N<	Gender=Fem|Number=Sing	13	amod	_	_
 15	durante	durante	ADP	PRP|@<ACC	_	17	case	_	_
 16	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
 17	piracema	piracema	NOUN	<np-def>|N|F|S|@P<	Gender=Fem|Number=Sing	11	obl	_	_

--- a/documents/CP0176.conllu
+++ b/documents/CP0176.conllu
@@ -219,7 +219,7 @@
 29	que	que	SCONJ	KS|@SUB	_	30	mark	_	_
 30	conseguimos	conseguir	VERB	<mv>|V|PS|1P|IND|@FS-<ACC	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	25	ccomp	_	_
 31	criar	criar	VERB	<mv>|V|INF|@ICL-<ACC	VerbForm=Inf	30	xcomp	_	_
-32	uma	um	DET	<arti>|ART|F|S|@>N	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	38	det	_	_
+32	uma	um	DET	<arti>|ART|F|S|@>N	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
 33	família	família	NOUN	<np-idf>|N|F|S|@<ACC	Gender=Fem|Number=Sing	31	obj	_	_
 34	credível	credível	ADJ	ADJ|F|S|@N<	Gender=Fem|Number=Sing	38	amod	_	_
 35	para	para	ADP	PRP|@<ACC	_	38	case	_	_

--- a/documents/CP0236.conllu
+++ b/documents/CP0236.conllu
@@ -63,7 +63,7 @@
 54	meios	meio	NOUN	<np-def>|N|M|P|@P<	Gender=Masc|Number=Plur	51	obl	_	_
 55	que	que	PRON	<rel>|INDP|M|P|@ACC>	Gender=Masc|Number=Plur|PronType=Rel	59	obj	_	_
 56	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	59	det	_	_
-57	sua	seu	DET	<poss>|DET|F|S|@>N	Gender=Fem|Number=Sing|PronType=Prs	59	det	_	_
+57	sua	seu	DET	<poss>|DET|F|S|@>N	Gender=Fem|Number=Sing|PronType=Prs	58	det	_	_
 58	grandeza	grandeza	NOUN	<np-def>|N|F|S|@SUBJ>	Gender=Fem|Number=Sing	59	nsubj	_	_
 59	requer	requerer	VERB	<cjt>|<mv>|V|PR|3S|IND|@FS-N<	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	54	acl:relcl	_	SpaceAfter=No
 60	.	.	PUNCT	PU|@PU	_	19	punct	_	_

--- a/documents/CP0419.conllu
+++ b/documents/CP0419.conllu
@@ -9,7 +9,7 @@
 5	para	para	SCONJ	<first-cjt>|PRP|@<PIV	_	6	mark	_	_
 6	impor	impor	VERB	<first-cjt>|<mv>|V|INF|@ICL-P<	VerbForm=Inf	4	xcomp	_	_
 7	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-8	seu	seu	DET	<poss>|<si>|DET|M|S|@>N	Gender=Masc|Number=Sing|PronType=Prs	12	det	_	_
+8	seu	seu	DET	<poss>|<si>|DET|M|S|@>N	Gender=Masc|Number=Sing|PronType=Prs	9	det	_	_
 9	domínio	domínio	NOUN	<np-def>|N|M|S|@<ACC	Gender=Masc|Number=Sing	6	obj	_	_
 10	directo	directo	ADJ	ADJ|M|S|@N<	Gender=Masc|Number=Sing	12	amod	_	_
 11	sobre	sobre	ADP	PRP|@<ACC	_	12	case	_	_

--- a/documents/CP0433.conllu
+++ b/documents/CP0433.conllu
@@ -10,7 +10,7 @@
 6	todas	todo	DET	<quant>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Tot	8	det	_	_
 7	estas	este	DET	<dem>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Dem	8	det	_	_
 8	medidas	medida	NOUN	N|F|P|@>N	Gender=Fem|Number=Plur	5	obj	_	_
-9	israelitas	israelita	ADJ	<np-def>|N|F|P|@<ACC	Gender=Fem|Number=Plur	5	amod	_	SpaceAfter=No
+9	israelitas	israelita	ADJ	<np-def>|N|F|P|@<ACC	Gender=Fem|Number=Plur	8	amod	_	SpaceAfter=No
 10	?	?	PUNCT	PU|@PU	_	5	punct	_	_
 
 # text = Chamamos a isto terrorismo de Estado organizado», acrescentou Arafat.

--- a/documents/CP0433.conllu
+++ b/documents/CP0433.conllu
@@ -7,8 +7,8 @@
 3	é	ser	AUX	PRP|@ADVL>	_	5	discourse	_	MWE=é_que|MWEPOS=INTJ
 4	que	que	SCONJ	N|M|S|@P<	_	3	fixed	_	_
 5	explicamos	explicar	VERB	<mv>|V|PR|1P|IND|@FS-QUE	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	todas	todo	DET	<quant>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Tot	9	det	_	_
-7	estas	este	DET	<dem>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Dem	9	det	_	_
+6	todas	todo	DET	<quant>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Tot	8	det	_	_
+7	estas	este	DET	<dem>|DET|F|P|@>N	Gender=Fem|Number=Plur|PronType=Dem	8	det	_	_
 8	medidas	medida	NOUN	N|F|P|@>N	Gender=Fem|Number=Plur	5	obj	_	_
 9	israelitas	israelita	ADJ	<np-def>|N|F|P|@<ACC	Gender=Fem|Number=Plur	5	amod	_	SpaceAfter=No
 10	?	?	PUNCT	PU|@PU	_	5	punct	_	_

--- a/documents/CP0680.conllu
+++ b/documents/CP0680.conllu
@@ -226,7 +226,7 @@
 7	obriga	obrigar	VERB	<cjt>|<mv>|V|PR|3S|IND|@FS-STA	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	conj	_	_
 8	a	a	SCONJ	PRP|@<PIV	_	13	mark	_	_
 9	que	que	SCONJ	KS|@SUB	_	13	mark	_	_
-10	as	o	DET	<artd>|ART|F|P|@>N	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	13	det	_	_
+10	as	o	DET	<artd>|ART|F|P|@>N	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	11	det	_	_
 11	sociedades	sociedade	NOUN	<np-def>|N|F|P|@SUBJ>	Gender=Fem|Number=Plur	13	nsubj	_	_
 12	gestoras	gestora	ADJ	_	Gender=Fem|Number=Plur	11	amod	_	_
 13	tenham	ter	VERB	<cjt>|<mv>|V|PR|3P|SUBJ|@FS-P<	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	_	_

--- a/documents/CP0897.conllu
+++ b/documents/CP0897.conllu
@@ -132,7 +132,7 @@
 20	em	em	ADP	PRP|@N<	_	21	case	_	_
 21	1987	1987	NUM	<year>|<card>|<date>|NUM|M|S|@P<	NumType=Card	19	nmod	_	_
 22	para	para	ADP	PRP|@N<	_	25	case	_	_
-23	os	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	25	det	_	_
+23	os	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	24	det	_	_
 24	actuais	actual	NOUN	<n>|ADJ|M|P|@>N	Gender=Masc|Number=Plur	25	amod	_	_
 25	600	600	NUM	<card>|<np-def>|NUM|M|P|@P<	NumType=Card	15	iobj	_	SpaceAfter=No
 26	,	,	PUNCT	PU|@PU	_	15	punct	_	_

--- a/documents/CP0897.conllu
+++ b/documents/CP0897.conllu
@@ -132,7 +132,7 @@
 20	em	em	ADP	PRP|@N<	_	21	case	_	_
 21	1987	1987	NUM	<year>|<card>|<date>|NUM|M|S|@P<	NumType=Card	19	nmod	_	_
 22	para	para	ADP	PRP|@N<	_	25	case	_	_
-23	os	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	24	det	_	_
+23	os	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	25	det	_	_
 24	actuais	actual	NOUN	<n>|ADJ|M|P|@>N	Gender=Masc|Number=Plur	25	amod	_	_
 25	600	600	NUM	<card>|<np-def>|NUM|M|P|@P<	NumType=Card	15	iobj	_	SpaceAfter=No
 26	,	,	PUNCT	PU|@PU	_	15	punct	_	_


### PR DESCRIPTION
Casos de ```DET NOUN```, onde ```DET``` tem relação det com outro token que não é ```NOUN```, casos que podem ser visualizados em [query](http://match.grew.fr/?corpus=UD_Portuguese-Bosque@dev&custom=6149bd9e11ea7).