### PR TITLE
Correct etc

### DIFF
--- a/documents/CF0324.conllu
+++ b/documents/CF0324.conllu
@@ -150,7 +150,7 @@
 # sent_id = CF324-8
 # source = CETENFolha n=324 cad=Dinheiro sec=eco sem=94a
 1	Os	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	det	_	_
-2	contribuintes	contribuinte	NOUN	<np-def>|N|M|P|@SUBJ>	Gender=Masc|Number=Plur	15	nsubj	_	_
+2	contribuintes	contribuinte	NOUN	<np-def>|N|M|P|@SUBJ>	Gender=Masc|Number=Plur	14	nsubj	_	_
 3	que	que	PRON	<rel>|INDP|M|P|@SUBJ>	Gender=Masc|Number=Plur|PronType=Rel	4	nsubj	_	_
 4	pagarem	pagar	VERB	<mv>|V|FUT|3P|SUBJ|@FS-N<	Mood=Sub|Number=Plur|Person=3|Tense=Fut|VerbForm=Fin	2	acl:relcl	_	_
 5	seus	seu	DET	<poss>|DET|M|P|@>N	Gender=Masc|Number=Plur|PronType=Prs	6	det	_	_
@@ -159,25 +159,23 @@
 8	IPTU	IPTU	PROPN	<first-cjt>|PROP|M|S|@N<PRED	Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
 9	,	,	PUNCT	PU|@PU	_	10	punct	_	_
 10	ISS	iss	NOUN	<np-idf>|N|M|S|@N<PRED	Gender=Masc|Number=Sing	8	conj	_	_
-11-12	etc.	_	_	_	_	_	_	_	SpaceAfter=No
-11	et	et	CCONJ	_	_	12	cc	_	_
-12	cetera	cetera	PRON	_	Gender=Masc|Number=Plur	8	conj	_	_
-13	)	)	PUNCT	PU|@PU	_	8	punct	_	_
-14	hoje	hoje	ADV	ADV|@ADVL>	_	15	advmod	_	_
-15	sairão	sair	VERB	<mv>|V|FUT|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
-16	ganhando	ganhar	VERB	<mv>|V|GER|@ICL-<ADVL	VerbForm=Ger	15	advcl	_	SpaceAfter=No
-17	,	,	PUNCT	PU|@PU	_	16	punct	_	_
-18	pois	pois	SCONJ	KS|@SUB	_	22	mark	_	_
-19	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
-20	cálculo	cálculo	NOUN	<np-def>|N|M|S|@SUBJ>	Gender=Masc|Number=Sing	22	nsubj:pass	_	_
-21	será	ser	AUX	<aux>|V|FUT|3S|IND|@FS-<ADVL	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	22	aux:pass	_	_
-22	feito	fazer	VERB	<pass>|<mv>|V|PCP|M|S|@ICL-AUX<	Gender=Masc|Number=Sing|VerbForm=Part|Voice=Pass	15	advcl	_	_
-23-24	pela	_	_	_	_	_	_	_	_
-23	por	por	ADP	PRP|@<ADVL	_	25	case	_	_
-24	a	o	DET	<-sam>|<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-25	UFM	UFM	PROPN	PROP|F|S|@P<	Gender=Fem|Number=Sing	22	obl	_	_
-26	de	de	ADP	PRP|@N<	_	27	case	_	_
-27	R$	R$	SYM	_	_	25	nmod	_	_
-28	26,54	26,54	NUM	<card>|NUM|M|P|@N<	NumType=Card	27	nummod	_	SpaceAfter=No
-29	.	.	PUNCT	PU|@PU	_	15	punct	_	_
+11	etc.	etc	ADV	_	_	8	advmod	_	SpaceAfter=No
+12	)	)	PUNCT	PU|@PU	_	8	punct	_	_
+13	hoje	hoje	ADV	ADV|@ADVL>	_	14	advmod	_	_
+14	sairão	sair	VERB	<mv>|V|FUT|3P|IND|@FS-STA	Mood=Ind|Number=Plur|Person=3|Tense=Fut|VerbForm=Fin	0	root	_	_
+15	ganhando	ganhar	VERB	<mv>|V|GER|@ICL-<ADVL	VerbForm=Ger	14	advcl	_	SpaceAfter=No
+16	,	,	PUNCT	PU|@PU	_	15	punct	_	_
+17	pois	pois	SCONJ	KS|@SUB	_	21	mark	_	_
+18	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
+19	cálculo	cálculo	NOUN	<np-def>|N|M|S|@SUBJ>	Gender=Masc|Number=Sing	21	nsubj:pass	_	_
+20	será	ser	AUX	<aux>|V|FUT|3S|IND|@FS-<ADVL	Mood=Ind|Number=Sing|Person=3|Tense=Fut|VerbForm=Fin	21	aux:pass	_	_
+21	feito	fazer	VERB	<pass>|<mv>|V|PCP|M|S|@ICL-AUX<	Gender=Masc|Number=Sing|VerbForm=Part|Voice=Pass	14	advcl	_	_
+22-23	pela	_	_	_	_	_	_	_	_
+22	por	por	ADP	PRP|@<ADVL	_	24	case	_	_
+23	a	o	DET	<-sam>|<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
+24	UFM	UFM	PROPN	PROP|F|S|@P<	Gender=Fem|Number=Sing	21	obl	_	_
+25	de	de	ADP	PRP|@N<	_	26	case	_	_
+26	R$	R$	SYM	_	_	24	nmod	_	_
+27	26,54	26,54	NUM	<card>|NUM|M|P|@N<	NumType=Card	26	nummod	_	SpaceAfter=No
+28	.	.	PUNCT	PU|@PU	_	14	punct	_	_
 


### PR DESCRIPTION
Relacionado ao issue #386, correção de caso mencionado no issue seguindo outros casos do corpus e verificando na documentação, sugiro aplicar esse padrão para outros casos de etc no corpus (http://match.grew.fr/?corpus=UD_Portuguese-Bosque@dev&custom=6189c9fd85132&clustering=e.label), como marcados com upos ```X``` e com lemma ```etc.```.