### PR TITLE
Correction of inconsistent article analysis

### DIFF
--- a/documents/CF0097.conllu
+++ b/documents/CF0097.conllu
@@ -70,7 +70,7 @@
 15	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
 16	Telepapo	Telepapo	PROPN	<cjt>|PROP|M|S|@<SUBJ	Gender=Masc|Number=Sing	8	conj	_	_
 17	e	e	CCONJ	<co-subj>|KC|@CO	_	19	cc	_	_
-18	o	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	19	det	_	_
+18	o	o	DET	<artd>|ART|M|P|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 19	Tá	Tá	PROPN	_	ExtPos=PROPN|Gender=Masc|Number=Sing	8	conj	_	_
 20	Na	Na	PROPN	_	Number=Sing	19	flat:name	_	_
 21	Hora	Hora	PROPN	_	Number=Sing	19	flat:name	_	_

--- a/documents/CF0150.conllu
+++ b/documents/CF0150.conllu
@@ -23,7 +23,7 @@
 10	eis	eis	ADP	PRP|@ADVL>	ExtPos=ADV	17	advmod	_	_
 11	que	que	SCONJ	N|M|S|@P<	_	10	fixed	_	_
 12	mais	mais	ADV	_	ExtPos=ADV	17	advmod	_	_
-13	uma	um	DET	_	Gender=Fem|Number=Sing	12	fixed	_	_
+13	uma	um	DET	_	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	fixed	_	_
 14	vez	vez	NOUN	N|M|S|@P<	Gender=Masc|Number=Sing	12	fixed	_	_
 15	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
 16	país	país	NOUN	<np-def>|N|M|S|@SUBJ>	Gender=Masc|Number=Sing	17	nsubj	_	_

--- a/documents/CP0146.conllu
+++ b/documents/CP0146.conllu
@@ -32,7 +32,7 @@
 27	respeitado	respeitar	VERB	<pass>|<mv>|V|PCP|M|S|@ICL-AUX<	Gender=Masc|Number=Sing|VerbForm=Part|Voice=Pass	25	xcomp	_	_
 28	em	em	ADP	PRP|@<ADVL	_	31	case	_	_
 29	todo	todo	DET	<quant>|DET|M|S|@>N	Gender=Masc|Number=Sing|PronType=Tot	31	det	_	_
-30	o	o	DET	<arti>|ART|M|S|@>N	Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
+30	o	o	DET	<arti>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
 31	mundo	mundo	NOUN	<np-def>|N|M|S|@P<	Gender=Masc|Number=Sing	27	obl	_	SpaceAfter=No
 32	,	,	PUNCT	PU|@PU	_	36	punct	_	_
 33	sempre	sempre	ADV	ADV|@ADVL>	_	36	advmod	_	_

--- a/documents/CP0160.conllu
+++ b/documents/CP0160.conllu
@@ -151,7 +151,7 @@
 8-9	destaca-se	_	_	_	_	_	_	_	_
 8	destaca	destacar	VERB	<mv>|V|PR|3S|IND|@FS-STA	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 9	se	se	PRON	PERS|M|3S|ACC|@<ACC-PASS	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	expl	_	_
-10	o	ele	PRON	<dem>|PERS|M|3S|ACC|@<SUBJ	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Dem	8	nsubj	_	_
+10	o	ele	PRON	<dem>|PERS|M|3S|ACC|@<SUBJ	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
 11	de	de	ADP	PRP|@N<	_	12	case	_	_
 12	dia	dia	NOUN	<np-idf>|N|M|S|@P<	Gender=Masc|Number=Sing	10	nmod	_	_
 13	3	3	NUM	<card>|NUM|M|P|@N<	NumType=Card	12	nummod	_	SpaceAfter=No

--- a/documents/CP0180.conllu
+++ b/documents/CP0180.conllu
@@ -170,7 +170,7 @@
 33	Macintosh	Macintosh	PROPN	PROP|F|S|@N<	Gender=Fem|Number=Sing	32	appos	_	_
 34	que	que	SCONJ	KS|@COM	_	36	mark	_	_
 35	com	com	ADP	<first-cjt>|PRP|@KOMP<	_	36	case	_	_
-36	a	ela	PRON	<first-cjt>|<dem>|PERS|F|S|@P<	Gender=Fem|Number=Sing|PronType=Dem	29	advcl	_	_
+36	a	ela	PRON	<first-cjt>|<dem>|PERS|F|S|@P<	Definite=Def|Gender=Fem|Number=Sing|PronType=Prs	29	advcl	_	_
 37	de	de	ADP	PRP|@N<	_	38	case	_	_
 38	Windows	Windows	PROPN	PROP|M|S|@P<	Gender=Masc|Number=Sing	36	nmod	_	SpaceAfter=No
 39	:	:	PUNCT	PU|@PU	_	5	punct	_	_

--- a/documents/CP0224.conllu
+++ b/documents/CP0224.conllu
@@ -96,7 +96,7 @@
 18	,	,	PUNCT	PU|@PU	_	21	punct	_	_
 19-20	pelo	_	_	_	_	_	_	_	_
 19	por	por	ADP	<sam->|PRP|@ADVL>	_	21	case	_	_
-20	o	o	PRON	<-sam>|DET|M|S|@>N	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	21	det	_	_
+20	o	o	PRON	<-sam>|DET|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
 21	que	que	PRON	<rel>|INDP|M|S|@P<	Gender=Masc|Number=Sing|PronType=Rel	17	appos	_	_
 22	o	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
 23	gerente	gerente	NOUN	<np-def>|N|M|S|@SUBJ>	Gender=Masc|Number=Sing	24	nsubj	_	_

--- a/documents/CP0566.conllu
+++ b/documents/CP0566.conllu
@@ -308,7 +308,7 @@
 16	,	,	PUNCT	PU|@PU	_	18	punct	_	_
 17	a	o	DET	<artd>|ART|F|S|@>N	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
 18	Volta	Volta	PROPN	_	ExtPos=PROPN|Gender=Fem|Number=Sing	10	appos	_	_
-19	a	o	DET	_	Number=Sing|PronType=Art	18	flat:name	_	_
+19	a	o	DET	_	Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
 20	Portugal	Portugal	PROPN	_	Number=Sing	18	flat:name	_	_
 21	em	em	ADP	PRP|@N<	_	22	case	_	_
 22	Bicicleta	Bicicleta	PROPN	PROP|@P<	Number=Sing	18	nmod	_	SpaceAfter=No

--- a/documents/CP0872.conllu
+++ b/documents/CP0872.conllu
@@ -20,7 +20,7 @@
 16	16	16	NUM	<card>|NUM|M|P|@>N	NumType=Card	17	nummod	_	_
 17	bits	bit	NOUN	<np-def>|N|M|P|@P<	Gender=Masc|Number=Plur	14	nmod	_	_
 18	que	que	PRON	<rel>|INDP|M|P|@ACC>	Gender=Masc|Number=Plur|PronType=Rel	21	obj	_	_
-19	a	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
+19	a	o	DET	<artd>|ART|M|S|@>N	Definite=Def|Gender=Masc|Number=Sing|PronType=Art|Typo=Yes	20	det	_	CorrectForm=o
 20	Nintendo	Nintendo	PROPN	PROP|F|S|@SUBJ>	Gender=Fem|Number=Sing	21	nsubj	_	_
 21	lançou	lançar	VERB	<mv>|V|PS|3S|IND|@FS-N<	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	acl:relcl	_	_
 22-23	no	_	_	_	_	_	_	_	_

--- a/documents/CP0935.conllu
+++ b/documents/CP0935.conllu
@@ -21,7 +21,7 @@
 15	a	a	PROPN	PROP|@P<	Number=Sing	13	nmod	_	_
 16	Igualdade	Igualdade	PROPN	PROP|@N<	Gender=Fem|Number=Sing	13	flat:name	_	_
 17	e	e	CCONJ	PROP|@N<	_	13	flat:name	_	_
-18	os	os	DET	PROP|@N<	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	flat:name	_	_
+18	os	o	DET	PROP|@N<	Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	flat:name	_	_
 19	Direitos	Direitos	PROPN	PROP	Gender=Masc|Number=Plur	13	flat:name	_	_
 20-21	das	_	_	_	_	_	_	_	_
 20	de	de	ADP	<sam->|PRP|@N<	_	22	case	_	_

--- a/documents/CP0956.conllu
+++ b/documents/CP0956.conllu
@@ -85,7 +85,7 @@
 32	importa	importar	VERB	<cjt>|<mv>|V|PR|3S|IND|@FS-N<	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	conj	_	_
 33	exorcizar	exorcizar	VERB	<mv>|V|INF|@ICL-<ACC	VerbForm=Inf	32	xcomp	_	_
 34	de	de	ADP	PRP|@<ADVL	ExtPos=SCONJ	33	mark	_	_
-35	uma	um	DET	<arti>|DET|F|S@>N	Definite=Ind|Gender=Fem|PronType=Art	34	fixed	_	_
+35	uma	um	DET	<arti>|DET|F|S@>N	Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	34	fixed	_	_
 36	vez	vez	NOUN	N|F|S|@P<	Gender=Fem|Number=Sing	34	fixed	_	_
 37	por	por	ADP	PRP|@N<	_	34	fixed	_	_
 38	todas	todas	PRON	<quant>|DET|F|P|@P<	Gender=Fem|Number=Plur|PronType=Tot	34	fixed	_	SpaceAfter=No


### PR DESCRIPTION
Relacionado ao issue #365, correções sobre o comentário https://github.com/UniversalDependencies/UD_Portuguese-Bosque/issues/365#issuecomment-961946706:

- `a ela Definite=Def|Gender=Fem|Number=Sing|PronType=Dem`:
	(CP180-5) Seguindo outros casos de adicionar `PronType=Prs` (no máximo agrupamos casos de erro).

- `a o Definite=Def|Gender=Masc|Number=Sing|PronType=Art`:
	(CP872-1) Adicionar `Typo=Yes` e `CorrectForm=o`.

- `a o Number=Sing|PronType=Art`:
	(CP566-6) Mudança na arvore e adicionar Gender e Definite.

- `o ele Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Dem`:
	(CP160-4) Seguindo outros casos de adicionar `PronType=Prs` (no máximo agrupamos casos de erro).

- `uma um Gender=Fem|Number=Sing`:
	(CF150-3) Adicionar features Definite and PronType.

- `uma um Definite=Ind|Gender=Fem|PronType=Art`:
	(CP956-3) Adicionar feature Number.

- `os os Definite=Def|Gender=Masc|Number=Plur|PronType=Art`:
	(CP935-1) lemma errado (mudança para lemma=o).

- `o o Definite=Def|Gender=Masc|Number=Plur|PronType=Art`:
	(CF97-3) ```Number = Sing```.
	(CP224-2) ```Number = Sing```.

- `o o Definite=Ind|Gender=Masc|Number=Sing|PronType=Art`:
	(CP146-1) ```Definite=Def```.